### PR TITLE
Fix_projectile_mass2

### DIFF
--- a/ESPNN/__main__.py
+++ b/ESPNN/__main__.py
@@ -12,17 +12,18 @@ class DefaultHelpParser(argparse.ArgumentParser):
 
 if __name__ == "__main__":
 
-    basic_usage = "python -m SPNN [X] [Xm] [Y] [Ym]"
+    basic_usage = "python -m ESPNN [X] [Y]"
+    custom_mass = "[-Ym YM]"
     custom_ener = " [-emin EMIN] [-emax EMAX] [-npoints NPOINTS] "
     custom_output = "[--plot PLOT] [--outdir OUTDIR]"
-    usage = ''.join([basic_usage, custom_ener, custom_output])
+    usage = ''.join([basic_usage, custom_mass,custom_ener, custom_output])
     # parser = argparse.ArgumentParser(usage=usage, add_help=False)
     parser = DefaultHelpParser(usage=usage, add_help=False)
 
     parser.add_argument("X", help="Projectile name", type=str)
-    parser.add_argument("Xm", help="Projectile mass", type=float, default=None)
     parser.add_argument("Y", help="Target name", type=str)
-    parser.add_argument("Ym", help="Target mass", type=float, default=None)
+    parser.add_argument("-Ym", help="Target mass", type=float, default=None)
+    parser.add_argument("-Xm", help="Projectile mass", type=float, default=None)
     parser.add_argument(
         "-emin",
         dest="emin",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ ESPNN.run_NN(projectile='He', projectile_mass=4.002602, target='Au', target_mass
 The ESPNN package can also be used from terminal with a syntaxis analogous to the above given:
 
 ```console
-python -m ESPNN He 4.002602 Au 196.966569
+python -m ESPNN H Au -Ym 196.966569
 ```
 
 Additional information about the optional arguments input can be obtained with the -h, --help flag:


### PR DESCRIPTION
This makes masses totally optional in tyhe CLI now, and be named arguments instead of position arguments

See


```console
python -m ESPNN H Au  -Ym 196.966569
```
